### PR TITLE
Help documentation diverged from code

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Available commands are:
 | `key`    | The DNS API access key.  This may also be specified by setting the `IPMAN_DNS_KEY` environment variable.
 | `secret` | The DNS API access secret.  This may also be specified by setting the `IPMAN_DNS_SECRET` environment variable.
 | `domain` | The DNS domain name. This value defaults to the domain portion of the local hostname.
-| `record` | The DNS record name. This defaults to the domain root alias ("@").
+| `name`   | The DNS record name. This defaults to the domain root alias ("@").
 | `ttl`    | The DNS record ttl in seconds.  This defaults to 600 seconds (5 minutes).
 
 ### Example

--- a/command/update/command.go
+++ b/command/update/command.go
@@ -70,7 +70,7 @@ Options:
 	-key      The DNS API access key.
 	-secret   The DNS API access secret.
 	-domain   The DNS domain name.            (default: local domain)
-	-record   The DNS record name.            (default: @)
+	-name     The DNS record name.            (default: @)
 	-ttl      The DNS record ttl in seconds.  (default: 600)
 `, c.Self)
 }

--- a/command/update/util.go
+++ b/command/update/util.go
@@ -38,7 +38,7 @@ func (c *Command) setupFlags(args []string) error {
 		"API secret key")
 	cmdFlags.StringVar(&c.config.domain, "domain", "",
 		"Domain name")
-	cmdFlags.StringVar(&c.config.name, "record", "@",
+	cmdFlags.StringVar(&c.config.name, "name", "@",
 		"Record name")
 	cmdFlags.IntVar(&c.config.ttl, "ttl", 600,
 		"TTL value")

--- a/command/update/util.go
+++ b/command/update/util.go
@@ -38,7 +38,7 @@ func (c *Command) setupFlags(args []string) error {
 		"API secret key")
 	cmdFlags.StringVar(&c.config.domain, "domain", "",
 		"Domain name")
-	cmdFlags.StringVar(&c.config.name, "name", "@",
+	cmdFlags.StringVar(&c.config.name, "record", "@",
 		"Record name")
 	cmdFlags.IntVar(&c.config.ttl, "ttl", 600,
 		"TTL value")


### PR DESCRIPTION
As coded, the parameter is "-name" instead of "-record" and I wanted the code to match the documentation.